### PR TITLE
example.api.com -> api.example.com

### DIFF
--- a/APIs/SinkMetadataProcessingAPI.raml
+++ b/APIs/SinkMetadataProcessingAPI.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: EDID Processing
-baseUri: http://example.api.com/x-nmos/edid/{version}
+baseUri: http://api.example.com/x-nmos/edid/{version}
 version: v1.0
 mediaType: application/json
 


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc2606#section-3, https://tools.ietf.org/html/rfc6761#section-6.5 (https://github.com/AMWA-TV/nmos-template/pull/24)