### PR TITLE
Link definition of media profile in senders's behavior

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -12,6 +12,6 @@ The terms ‘Device’, ‘Source’, ‘Flow’, ‘Sender’, ‘Receiver’ a
 
 A media consuming unit associated with an IS-04 Receiver. Sink is a resource and based on Resource Core JSON Schema.
 
-### Media Profile
+### Media Profiles
 
-Media description which describes a format acceptable for all Receivers implied to be a part of a connection. A Media Profile consist of separate parameters required to set up Sender and such IS-04 resources behind it as Source and Flow.
+A Collection of formats that are acceptable for all Receivers implied to be a part of a connection. A Media Profile consist of separate parameters required to set a Sender, Flow, and/or Source.

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -14,4 +14,4 @@ A media consuming unit associated with an IS-04 Receiver. Sink is a resource and
 
 ### Media Profile
 
-A Collection of formats that are acceptable for all Receivers implied to be a part of a connection. A Media Profile consist of separate parameters required to set a Sender, Flow, and/or Source.
+Description of a format that is acceptable for all Receivers implied to be a part of a connection. A Media Profile consist of separate media parameters required to set a Sender, Flow, and/or Source.

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -12,6 +12,6 @@ The terms ‘Device’, ‘Source’, ‘Flow’, ‘Sender’, ‘Receiver’ a
 
 A media consuming unit associated with an IS-04 Receiver. Sink is a resource and based on Resource Core JSON Schema.
 
-### Media Profiles
+### Media Profile
 
 A Collection of formats that are acceptable for all Receivers implied to be a part of a connection. A Media Profile consist of separate parameters required to set a Sender, Flow, and/or Source.

--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -4,7 +4,7 @@ The Sink Metadata Processing API provides a mechanism to change the settings ass
 
 ## Senders
 
-`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender and let the device which controls it choose what exact format to use. A client can also pass a single Media Profile to specify the exact format.
+`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender and let the underlying component control which it choose exactly which format to use. A client can also pass a single Media Profile to specify the exact format.
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such a Sender via IS-05 doesn't involve the Sink Metadata Processing API.
 

--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -4,7 +4,7 @@ The Sink Metadata Processing API provides a mechanism to change the settings ass
 
 ## Senders
 
-`/media-profiles` allows the client to pass an array of Media Profiles to a Sender and let a third-party which controls it choose what exact format to use. A client can also pass a single Media Profile to specify the exact format.
+`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender and let the device which controls it choose what exact format to use. A client can also pass a single Media Profile to specify the exact format.
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such a Sender via IS-05 doesn't involve the Sink Metadata Processing API.
 


### PR DESCRIPTION
This is required to understand the meaning and implication of what the endpoint is enabled and how it should be used.
Highlighting it should make it easier for those reading and trying to follow.