### PR TITLE
Replace "media parameters" with "media profile"

### DIFF
--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -10,7 +10,7 @@ The initial state of Media Profiles of any Sender is empty. Creating a connectio
 
 A `GET` request returns the last successfully applied Media Profiles array.
 
-A `PUT` request MUST be validated and if the Device fully supports the proposed media parameters, it initiates an attempt to reconfigure the Device and update corresponding Flow and/or Source and/or Sender properties. If successful, the operation MUST return the accepted Media Profiles array, otherwise an error MUST be returned and nothing changed.
+A `PUT` request MUST be validated and if the Device supports the proposed media profile, it initiates an attempt to reconfigure the Device and update corresponding Flow, Source, and/or Sender properties. If successful, the operation MUST return the accepted Media Profiles array, otherwise an error MUST be returned and nothing changed.
 
 A `DELETE` request MUST clear the last successfully applied Media Profiles array.
 


### PR DESCRIPTION
I removed the work "fully" since it seemed out of place.

If a device supports at least one of the requested media profile it's expected to fulfill that subset, in other words accept the request with partial support?

