### PR TITLE
Describe format change beyond NMOS

### DIFF
--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -4,7 +4,7 @@ The Sink Metadata Processing API provides a mechanism to change the settings ass
 
 ## Senders
 
-`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender, let the underlying component choose exactly which format to use at the moment and dictate that format changes which are not consequent to Media Profiles change MUST lay within Media Profiles set. A client can also pass a single Media Profile to specify the exact format.
+`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender allowing the underlying component choose exactly which format to use at the moment and dictate that format changes which are not consequent to Media Profiles change MUST lay within Media Profiles set. A client can also pass a single Media Profile to specify the exact format.
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such a Sender via IS-05 doesn't involve the Sink Metadata Processing API.
 

--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -4,7 +4,7 @@ The Sink Metadata Processing API provides a mechanism to change the settings ass
 
 ## Senders
 
-`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender and let the underlying component control which it choose exactly which format to use. A client can also pass a single Media Profile to specify the exact format.
+`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender, let the underlying component choose exactly which format to use at the moment and dictate that format changes which are not consequent to Media Profiles change MUST lay within Media Profiles set. A client can also pass a single Media Profile to specify the exact format.
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such a Sender via IS-05 doesn't involve the Sink Metadata Processing API.
 

--- a/docs/1.2. Behaviour.md
+++ b/docs/1.2. Behaviour.md
@@ -4,7 +4,7 @@ The Sink Metadata Processing API provides a mechanism to change the settings ass
 
 ## Senders
 
-`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender allowing the underlying component choose exactly which format to use at the moment and dictate that format changes which are not consequent to Media Profiles change MUST lay within Media Profiles set. A client can also pass a single Media Profile to specify the exact format.
+`/senders/{senderId}/media-profiles` allows the client to pass an array of [Media Profiles](1.0.%20Overview.md#media-profile) to a Sender allowing the underlying component choose exactly which format to use at the moment and dictates that format changes which are not consequent to Media Profiles change MUST lay within Media Profiles set. A client can also pass a single Media Profile to specify the exact format.
 
 The initial state of Media Profiles of any Sender is empty. Creating a connection with such a Sender via IS-05 doesn't involve the Sink Metadata Processing API.
 


### PR DESCRIPTION
It is possible that the underlying component behind a Device with a Sender changes format on its own. This PR adds a requirement for changes to stay within Media Profiles set.