### PR TITLE
Remove bit_depth from media_profile_audio.json

### DIFF
--- a/APIs/schemas/media_profile_audio.json
+++ b/APIs/schemas/media_profile_audio.json
@@ -47,10 +47,6 @@
         }
       ]
     },
-    "bit_depth" : {
-      "description" : "Bit depth of the audio samples",
-      "type" : "integer"
-    },
     "channel_count" : {
       "description" : "Identifies the acceptable number of channels of an audio stream. It is complementary to Receiver Caps Parameter Constraint of the same name.",
       "type" : "integer",


### PR DESCRIPTION
Discussed in https://github.com/AMWA-TV/nmos-edid-to-receiver-caps-mapping/issues/58.