### PR TITLE
Use nmos-render docker

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -14,31 +14,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: '12.x'
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-      - name: Install Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: '2.x'
-      - name: Install Bundler
-        run: gem install bundler
-      - name: Setup 
-        run: make -C .render distclean build-tools
-      - name: Build site
-        run: make -C .render build
-      - name: Upload site
-        run: make -C .render upload
+      - name: Use NMOS Render
+        uses: docker://amwa/nmos-render:latest
         env:
-          SSH_HOST: ${{ secrets.SSH_HOST }} 
+          SSH_HOST: ${{ secrets.SSH_HOST }}
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -2,5 +2,4 @@
 
 set -o errexit
 
-git clone --single-branch --branch deploy-action https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
-.scripts/install-dependencies.sh
+git clone --single-branch --branch "${NMOS_DOC_BUILD_SCRIPTS_BRANCH:-main}" https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts

--- a/.render/.init-scripts/make-build-tools.sh
+++ b/.render/.init-scripts/make-build-tools.sh
@@ -2,5 +2,5 @@
 
 set -o errexit
 
-git clone --single-branch --branch main https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
+git clone --single-branch --branch deploy-action https://${GITHUB_TOKEN:+${GITHUB_TOKEN}@}github.com/AMWA-TV/nmos-doc-build-scripts .scripts
 .scripts/install-dependencies.sh

--- a/.render/Gemfile
+++ b/.render/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'faraday', '~>0'
-
-gem "webrick", "~> 1.7"

--- a/.render/Gemfile
+++ b/.render/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'faraday', '~>0'
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
The render workflow now uses the `amwa/nmos-render` container, instead of installing python, node, perl, ruby, jekyll etc and the build scripts each time.

See also https://github.com/AMWA-TV/nmos-doc-build-scripts/pull/42 and make sure the branch that is used there is consistent before merging this.